### PR TITLE
Start E2E testing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ tool/
 .eslintrc
 circle.yml
 karma.conf.js
+/e2e

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,34 @@
+Tweakpane E2E testing
+=====================
+
+
+
+
+Purporse
+--------
+
+- Ensuring compatibility for popular module systems (Global, CommonJS, AMD)
+- Lightweight system testing
+
+
+
+
+How to run
+----------
+You can run the e2e test by the command:
+
+```console
+$ npm run test:e2e
+```
+
+
+
+
+How to debug
+------------
+You can debug the e2e test by using debugger consoles. The following command start a web server that is equivalent to the used by E2E testing:
+
+```console
+$ node e2e/manual-test.js
+Server is ready. Please open http://localhost:9998.
+```

--- a/e2e/manual-test.js
+++ b/e2e/manual-test.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+'use strict';
+
+const PORT = process.env.PORT || 9998;
+const HOSTNAME = process.env.HOSTNAME || 'localhost';
+
+const createServerController = require('./server.js');
+const controller = createServerController(PORT, HOSTNAME);
+controller.waitForStart()
+  .then(() => {
+    console.info(`Server is ready. Please open http://${HOSTNAME}:${PORT}.`);
+  });

--- a/e2e/public/import_via_amd.html
+++ b/e2e/public/import_via_amd.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test for AMD import</title>
+  <link rel="stylesheet" href="/dst/tweakpane.css" media="all">
+</head>
+<body>
+  <script src="/node_modules/requirejs/require.js"></script>
+  <script>
+    requirejs.config({
+      paths: { tweakpane: '/dst/tweakpane' }
+    });
+
+    requirejs(['./import_via_amd.js']);
+  </script>
+</body>
+</html>

--- a/e2e/public/import_via_amd.js
+++ b/e2e/public/import_via_amd.js
@@ -1,0 +1,20 @@
+/* global requirejs */
+requirejs(['tweakpane'], function(Tweakpane) {
+  var observable = {
+    x: 0,
+  };
+
+  setInterval(function() {
+    var progress = (Date.now() % 1000) / 1000;
+    observable.x = Math.sin(progress * 2 * Math.PI);
+  }, 100);
+
+  var pane = new Tweakpane();
+  var folder = pane.addFolder('Graph');
+  folder.addGraph(observable, 'x', {
+    label: 'sin',
+    count: 50,
+    min: -1.0,
+    max: 1.0
+  });
+});

--- a/e2e/public/import_via_commonjs.html
+++ b/e2e/public/import_via_commonjs.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test for CommonJS import</title>
+  <link rel="stylesheet" href="/dst/tweakpane.css" media="all">
+</head>
+<body>
+  <script src="node_modules/systemjs/dist/system-polyfills.src.js"></script>
+  <script src="node_modules/systemjs/dist/system.src.js"></script>
+  <script>
+    System.config({
+      map: {
+        tweakpane: '/dst/cjs'
+      },
+      packages: {
+        tweakpane: {
+          main: 'tweakpane',
+          format: 'cjs',
+          defaultExtensions: 'js',
+        }
+      }
+    });
+
+    System.import('./import_via_commonjs.js');
+  </script>
+</body>
+</html>

--- a/e2e/public/import_via_commonjs.js
+++ b/e2e/public/import_via_commonjs.js
@@ -1,0 +1,20 @@
+/* global require */
+var Tweakpane = require('tweakpane');
+
+var observable = {
+  x: 0,
+};
+
+setInterval(function() {
+  var progress = (Date.now() % 1000) / 1000;
+  observable.x = Math.sin(progress * 2 * Math.PI);
+}, 100);
+
+var pane = new Tweakpane();
+var folder = pane.addFolder('Graph');
+folder.addGraph(observable, 'x', {
+  label: 'sin',
+  count: 50,
+  min: -1.0,
+  max: 1.0
+});

--- a/e2e/public/import_via_global.html
+++ b/e2e/public/import_via_global.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test for Global import</title>
+  <link rel="stylesheet" href="/dst/tweakpane.css" media="all">
+</head>
+<body>
+  <script src="/dst/tweakpane.js"></script>
+  <script src="./import_via_global.js"></script>
+</body>
+</html>

--- a/e2e/public/import_via_global.js
+++ b/e2e/public/import_via_global.js
@@ -1,0 +1,18 @@
+/* global Tweakpane */
+var observable = {
+  x: 0,
+};
+
+setInterval(function() {
+  var progress = (Date.now() % 1000) / 1000;
+  observable.x = Math.sin(progress * 2 * Math.PI);
+}, 100);
+
+var pane = new Tweakpane();
+var folder = pane.addFolder('Graph');
+folder.addGraph(observable, 'x', {
+  label: 'sin',
+  count: 50,
+  min: -1.0,
+  max: 1.0
+});

--- a/e2e/server.js
+++ b/e2e/server.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const webdriver = require('selenium-webdriver');
+const Path = require('path');
+const Http = require('http');
+const express = require('express');
+const serveIndex = require('serve-index');
+
+const BASE_DIR = Path.join(__dirname, '..');
+
+
+function createServer() {
+  const StaticResourceMap = {
+    '/': Path.join(BASE_DIR, 'e2e/public'),
+    '/src': Path.join(BASE_DIR, 'src/main/js'),
+    '/dst': Path.join(BASE_DIR, 'dst'),
+    '/node_modules': Path.join(BASE_DIR, 'node_modules'),
+  };
+
+  const app = express();
+
+  for (let webUrl in StaticResourceMap) {
+    const filePath = StaticResourceMap[webUrl];
+    app.use(webUrl, serveIndex(filePath));
+    app.use(webUrl, express.static(filePath));
+  }
+
+  return Http.createServer(app);
+}
+
+
+function createServerController(port, hostname) {
+  const promisedServer = new webdriver.promise.Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.on('listening', () => {
+      resolve(server);
+    });
+
+    server.on('error', (error) => {
+      reject(error);
+    });
+
+    server.listen(port, hostname);
+  });
+
+  return {
+    waitForStart: () => promisedServer,
+    stop: () => promisedServer.then((server) => server.close()),
+  };
+}
+
+
+module.exports = createServerController;

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const webdriver = require('selenium-webdriver');
+const By = webdriver.By;
+const until = webdriver.until;
+const testing = require('selenium-webdriver/testing');
+
+const describe = testing.describe;
+const context = testing.describe;
+const it = testing.it;
+const before = testing.before;
+const after = testing.after;
+
+const createServerController = require('./server.js');
+
+const TIMEOUT_MSEC = 60 * 1000;
+const PORT = 9999;
+const HOSTNAME = 'localhost';
+const BASE_URL = `http://${HOSTNAME}:${PORT}`;
+
+
+describe('Tweakpane', function() {
+  this.timeout(TIMEOUT_MSEC);
+
+  let driver;
+  let serverController;
+
+
+  before(() => {
+    driver = new webdriver.Builder()
+      .forBrowser('chrome')
+      .build();
+
+    serverController = createServerController(9999, 'localhost');
+    return serverController.waitForStart();
+  });
+
+
+  context('when using global', () => {
+    it('should be able to display a monitor', () => {
+      driver.get(`${BASE_URL}/import_via_global.html`);
+
+      return driver.wait(until.elementLocated(By.tagName('canvas')), 10000);
+    });
+  });
+
+
+  context('when using commonjs', () => {
+    it('should be able to display a monitor', () => {
+      driver.get(`${BASE_URL}/import_via_commonjs.html`);
+
+      return driver.wait(until.elementLocated(By.tagName('canvas')), 10000);
+    });
+  });
+
+
+  context('when using amd', () => {
+    it('should be able to display a monitor', () => {
+      driver.get(`${BASE_URL}/import_via_amd.html`);
+
+      return driver.wait(until.elementLocated(By.tagName('canvas')), 10000);
+    });
+  });
+
+
+  after(() => {
+    serverController.stop();
+    return driver.quit();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "sass": "src/main/sass/tweakpane.scss",
   "scripts": {
     "prepublish": "gulp prepublish",
-    "test": "node_modules/karma/bin/karma start",
+    "test": "npm-run-all test:unit test:e2e",
+    "test:unit": "node_modules/karma/bin/karma start",
+    "test:e2e": "mocha e2e/test.js",
     "lint": "node node_modules/eslint/bin/eslint.js src/main/js",
     "prerelease": "tool/prerelease.sh"
   },
@@ -27,8 +29,10 @@
     "babelify": "^7.3.0",
     "browserify": "^12.0.1",
     "chai": "^3.5.0",
+    "chromedriver": "^2.21.2",
     "del": "^2.2.1",
     "eslint": "^2.13.1",
+    "express": "^4.14.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
@@ -48,8 +52,13 @@
     "karma-mocha-reporter": "^2.0.4",
     "karma-sinon": "^1.0.4",
     "mocha": "^2.5.3",
+    "npm-run-all": "^2.3.0",
+    "requirejs": "^2.2.0",
     "run-sequence": "^1.2.2",
+    "selenium-webdriver": "^2.53.3",
+    "serve-index": "^1.8.0",
     "sinon": "^1.17.3",
+    "systemjs": "^0.19.31",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }


### PR DESCRIPTION
Purporse
--------

- Ensuring compatibility for popular module systems (Global, CommonJS, AMD)
- Lightweight system testing




How to run
----------
You can run the e2e test by the command:

```console
$ npm run test:e2e
```




How to debug
------------
You can debug the e2e test by using debugger consoles. The following command start a web server that is equivalent to the used by E2E testing:

```console
$ node e2e/manual-test.js
Server is ready. Please open http://localhost:9998.
```
