### PR TITLE
Add support for functional color notation

### DIFF
--- a/src/doc/js/route/input.ts
+++ b/src/doc/js/route/input.ts
@@ -173,12 +173,14 @@ export const InputRoute = {
 			},
 			stringColor: (container) => {
 				const PARAMS = {
-					tint: '#8df',
+					primary: '#8df',
+					secondary: 'rgb(255, 136, 221)',
 				};
 				const pane = new Tweakpane({
 					container: container,
 				});
-				pane.addInput(PARAMS, 'tint');
+				pane.addInput(PARAMS, 'primary');
+				pane.addInput(PARAMS, 'secondary');
 			},
 			numberColor: (container) => {
 				const PARAMS = {

--- a/src/doc/template/input.html
+++ b/src/doc/template/input.html
@@ -206,11 +206,13 @@ pane.addInput(PARAMS, 'tint');</code></pre></div>
 	<div class="common-demo">
 		<div class="common-demo_codeLayout">
 			<div class="common-codeBlock"><pre><code class="js">const PARAMS = {
-  tint: '#8df',
+  primary: '#8df',
+  secondary: 'rgb(255, 136, 221)',
 };
 
 const pane = new Tweakpane();
-pane.addInput(PARAMS, 'tint');</code></pre></div>
+pane.addInput(PARAMS, 'primary');
+pane.addInput(PARAMS, 'secondary');</code></pre></div>
 		</div>
 		<div class="common-demo_resultLayout">
 			<div class="common-paneContainer common-paneContainer-stringColor"></div>

--- a/src/main/js/api/root-color-input-test.ts
+++ b/src/main/js/api/root-color-input-test.ts
@@ -7,6 +7,7 @@ import {RootController} from '../controller/root';
 import {TestUtil} from '../misc/test-util';
 import {Class} from '../misc/type-util';
 import {Color} from '../model/color';
+import {ColorSwatchTextInputView} from '../view/input/color-swatch-text';
 import {RootApi} from './root';
 import {InputParams} from './types';
 
@@ -55,6 +56,41 @@ describe(RootApi.name, () => {
 				const obj = {foo: testCase.value};
 				const bapi = api.addInput(obj, 'foo', testCase.params);
 				assert.instanceOf(bapi.controller.controller, testCase.expectedClass);
+			});
+		});
+	});
+
+	[
+		{
+			expected: {
+				inputValue: '#112233',
+			},
+			params: {
+				input: '#123',
+			},
+		},
+		{
+			expected: {
+				inputValue: 'rgb(0, 128, 255)',
+			},
+			params: {
+				input: 'rgb(0,128,255)',
+			},
+		},
+	].forEach((testCase) => {
+		context(`when params = ${JSON.stringify(testCase.params)}`, () => {
+			it(`should be hoge ${testCase.expected.inputValue}`, () => {
+				const api = createApi();
+				const obj = {foo: testCase.params.input};
+				const bapi = api.addInput(obj, 'foo');
+
+				const view = bapi.controller.controller.view;
+				if (!(view instanceof ColorSwatchTextInputView)) {
+					throw new Error('hoge');
+				}
+
+				const inputElem = view.textInputView.inputElement;
+				assert.equal(inputElem.value, testCase.expected.inputValue);
 			});
 		});
 	});

--- a/src/main/js/controller/binding-creators/color-input.ts
+++ b/src/main/js/controller/binding-creators/color-input.ts
@@ -6,7 +6,7 @@ import {Color, RgbColorObject} from '../../model/color';
 import {InputValue} from '../../model/input-value';
 import {Target} from '../../model/target';
 import {NumberColorParser} from '../../parser/number-color';
-import {StringColorParser} from '../../parser/string-color';
+import * as StringColorParser from '../../parser/string-color';
 import {InputBindingController} from '../input-binding';
 import {ColorSwatchTextInputController} from '../input/color-swatch-text';
 
@@ -22,22 +22,24 @@ export function createWithString(
 	if (typeof initialValue !== 'string') {
 		return null;
 	}
-	const color = StringColorParser(initialValue);
-	if (!color) {
+	const notation = StringColorParser.getNotation(initialValue);
+	if (!notation) {
 		return null;
 	}
 
+	const converter = ColorConverter.fromMixed;
+	const color = converter(initialValue);
 	const value = new InputValue(color);
 	return new InputBindingController(document, {
 		binding: new InputBinding({
-			reader: ColorConverter.fromMixed,
+			reader: converter,
 			target: target,
 			value: value,
-			writer: ColorConverter.toString,
+			writer: ColorConverter.getStringConverter(notation),
 		}),
 		controller: new ColorSwatchTextInputController(document, {
 			formatter: new ColorFormatter(),
-			parser: StringColorParser,
+			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),
 		label: params.label || target.key,
@@ -77,7 +79,7 @@ export function createWithNumber(
 		}),
 		controller: new ColorSwatchTextInputController(document, {
 			formatter: new ColorFormatter(),
-			parser: StringColorParser,
+			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),
 		label: params.label || target.key,
@@ -108,7 +110,7 @@ export function createWithObject(
 		}),
 		controller: new ColorSwatchTextInputController(document, {
 			formatter: new ColorFormatter(),
-			parser: StringColorParser,
+			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),
 		label: params.label || target.key,

--- a/src/main/js/controller/binding-creators/color-input.ts
+++ b/src/main/js/controller/binding-creators/color-input.ts
@@ -30,15 +30,16 @@ export function createWithString(
 	const converter = ColorConverter.fromMixed;
 	const color = converter(initialValue);
 	const value = new InputValue(color);
+	const writer = ColorConverter.getStringifier(notation);
 	return new InputBindingController(document, {
 		binding: new InputBinding({
 			reader: converter,
 			target: target,
 			value: value,
-			writer: ColorConverter.getStringConverter(notation),
+			writer: writer,
 		}),
 		controller: new ColorSwatchTextInputController(document, {
-			formatter: new ColorFormatter(),
+			formatter: new ColorFormatter(writer),
 			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),
@@ -78,7 +79,7 @@ export function createWithNumber(
 			writer: ColorConverter.toNumber,
 		}),
 		controller: new ColorSwatchTextInputController(document, {
-			formatter: new ColorFormatter(),
+			formatter: new ColorFormatter(ColorConverter.toHexRgbString),
 			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),
@@ -109,7 +110,7 @@ export function createWithObject(
 			writer: Color.toRgbObject,
 		}),
 		controller: new ColorSwatchTextInputController(document, {
-			formatter: new ColorFormatter(),
+			formatter: new ColorFormatter(ColorConverter.toHexRgbString),
 			parser: StringColorParser.CompositeParser,
 			value: value,
 		}),

--- a/src/main/js/controller/input/color-swatch-text-test.ts
+++ b/src/main/js/controller/input/color-swatch-text-test.ts
@@ -1,6 +1,7 @@
 import {assert} from 'chai';
 import {describe, it} from 'mocha';
 
+import * as ColorConverter from '../../converter/color';
 import {ColorFormatter} from '../../formatter/color';
 import {TestUtil} from '../../misc/test-util';
 import {Color} from '../../model/color';
@@ -12,7 +13,7 @@ describe(ColorSwatchTextInputController.name, () => {
 	it('should dispose', () => {
 		const doc = TestUtil.createWindow().document;
 		const c = new ColorSwatchTextInputController(doc, {
-			formatter: new ColorFormatter(),
+			formatter: new ColorFormatter(ColorConverter.toHexRgbString),
 			parser: StringColorParser.CompositeParser,
 			value: new InputValue(new Color([0, 0, 0], 'rgb')),
 		});

--- a/src/main/js/controller/input/color-swatch-text-test.ts
+++ b/src/main/js/controller/input/color-swatch-text-test.ts
@@ -5,7 +5,7 @@ import {ColorFormatter} from '../../formatter/color';
 import {TestUtil} from '../../misc/test-util';
 import {Color} from '../../model/color';
 import {InputValue} from '../../model/input-value';
-import {StringColorParser} from '../../parser/string-color';
+import * as StringColorParser from '../../parser/string-color';
 import {ColorSwatchTextInputController} from './color-swatch-text';
 
 describe(ColorSwatchTextInputController.name, () => {
@@ -13,7 +13,7 @@ describe(ColorSwatchTextInputController.name, () => {
 		const doc = TestUtil.createWindow().document;
 		const c = new ColorSwatchTextInputController(doc, {
 			formatter: new ColorFormatter(),
-			parser: StringColorParser,
+			parser: StringColorParser.CompositeParser,
 			value: new InputValue(new Color([0, 0, 0], 'rgb')),
 		});
 		c.dispose();

--- a/src/main/js/converter/color-test.ts
+++ b/src/main/js/converter/color-test.ts
@@ -67,7 +67,31 @@ describe('ColorConverter', () => {
 		context(`when input = ${JSON.stringify(testCase.input)}`, () => {
 			it('should convert color to string', () => {
 				assert.strictEqual(
-					ColorConverter.toString(testCase.input),
+					ColorConverter.toHexRgbString(testCase.input),
+					testCase.expected,
+				);
+			});
+		});
+	});
+
+	[
+		{
+			input: new Color([0, 0, 0], 'rgb'),
+			expected: 'rgb(0, 0, 0)',
+		},
+		{
+			input: new Color([0, 127, 255], 'rgb'),
+			expected: 'rgb(0, 127, 255)',
+		},
+		{
+			input: new Color([255, 255, 255], 'rgb'),
+			expected: 'rgb(255, 255, 255)',
+		},
+	].forEach((testCase) => {
+		context(`when input = ${JSON.stringify(testCase.input)}`, () => {
+			it('should convert color to string', () => {
+				assert.strictEqual(
+					ColorConverter.toFunctionalRgbString(testCase.input),
 					testCase.expected,
 				);
 			});

--- a/src/main/js/converter/color.ts
+++ b/src/main/js/converter/color.ts
@@ -1,3 +1,4 @@
+import {NumberFormatter} from '../formatter/number';
 import {NumberUtil} from '../misc/number-util';
 import {Color} from '../model/color';
 import {NumberColorParser} from '../parser/number-color';
@@ -44,21 +45,24 @@ export function toHexRgbString(value: Color): string {
  * @hidden
  */
 export function toFunctionalRgbString(value: Color): string {
-	const comps = value.getComponents('rgb');
+	const formatter = new NumberFormatter(0);
+	const comps = value
+		.getComponents('rgb')
+		.map((comp) => formatter.format(comp));
 	return `rgb(${comps.join(', ')})`;
 }
 
-const NOTATION_TO_STRING_CONVERTER_MAP: {
+const NOTATION_TO_STRINGIFIER_MAP: {
 	[notation in StringColorNotation]: (value: Color) => string;
 } = {
 	'func.rgb': toFunctionalRgbString,
 	'hex.rgb': toHexRgbString,
 };
 
-export function getStringConverter(
+export function getStringifier(
 	notation: StringColorNotation,
 ): (value: Color) => string {
-	return NOTATION_TO_STRING_CONVERTER_MAP[notation];
+	return NOTATION_TO_STRINGIFIER_MAP[notation];
 }
 
 /**

--- a/src/main/js/converter/color.ts
+++ b/src/main/js/converter/color.ts
@@ -1,14 +1,15 @@
 import {NumberUtil} from '../misc/number-util';
 import {Color} from '../model/color';
 import {NumberColorParser} from '../parser/number-color';
-import {StringColorParser} from '../parser/string-color';
+import * as StringColorParser from '../parser/string-color';
+import {StringColorNotation} from '../parser/string-color';
 
 /**
  * @hidden
  */
 export function fromMixed(value: unknown): Color {
 	if (typeof value === 'string') {
-		const cv = StringColorParser(value);
+		const cv = StringColorParser.CompositeParser(value);
 		if (cv) {
 			return cv;
 		}
@@ -28,7 +29,7 @@ export function fromMixed(value: unknown): Color {
 /**
  * @hidden
  */
-export function toString(value: Color): string {
+export function toHexRgbString(value: Color): string {
 	const hexes = value
 		.getComponents('rgb')
 		.map((comp) => {
@@ -37,6 +38,27 @@ export function toString(value: Color): string {
 		})
 		.join('');
 	return `#${hexes}`;
+}
+
+/**
+ * @hidden
+ */
+export function toFunctionalRgbString(value: Color): string {
+	const comps = value.getComponents('rgb');
+	return `rgb(${comps.join(', ')})`;
+}
+
+const NOTATION_TO_STRING_CONVERTER_MAP: {
+	[notation in StringColorNotation]: (value: Color) => string;
+} = {
+	'func.rgb': toFunctionalRgbString,
+	'hex.rgb': toHexRgbString,
+};
+
+export function getStringConverter(
+	notation: StringColorNotation,
+): (value: Color) => string {
+	return NOTATION_TO_STRING_CONVERTER_MAP[notation];
 }
 
 /**

--- a/src/main/js/formatter/color-test.ts
+++ b/src/main/js/formatter/color-test.ts
@@ -1,6 +1,7 @@
 import {assert} from 'chai';
 import {describe, describe as context, it} from 'mocha';
 
+import * as ColorConverter from '../converter/color';
 import {Color} from '../model/color';
 import {ColorFormatter} from './color';
 
@@ -54,7 +55,7 @@ describe(ColorFormatter.name, () => {
 		context(`when ${JSON.stringify(testCase.components)}`, () => {
 			it(`it should format to ${JSON.stringify(testCase.hex)}`, () => {
 				const c = new Color(testCase.components, 'rgb');
-				const f = new ColorFormatter();
+				const f = new ColorFormatter(ColorConverter.toHexRgbString);
 				assert.strictEqual(f.format(c), testCase.hex);
 			});
 			it(`it should format to ${JSON.stringify(testCase.rgb)}`, () => {

--- a/src/main/js/formatter/color.ts
+++ b/src/main/js/formatter/color.ts
@@ -26,6 +26,6 @@ export class ColorFormatter implements Formatter<Color> {
 	}
 
 	public format(value: Color): string {
-		return ColorConverter.toString(value);
+		return ColorConverter.toHexRgbString(value);
 	}
 }

--- a/src/main/js/formatter/color.ts
+++ b/src/main/js/formatter/color.ts
@@ -1,4 +1,3 @@
-import * as ColorConverter from '../converter/color';
 import {NumberUtil} from '../misc/number-util';
 import {Color} from '../model/color';
 import {Formatter} from './formatter';
@@ -25,7 +24,13 @@ export class ColorFormatter implements Formatter<Color> {
 		return `hsl(${compsText})`;
 	}
 
+	private stringifier_: (color: Color) => string;
+
+	constructor(stringifier: (color: Color) => string) {
+		this.stringifier_ = stringifier;
+	}
+
 	public format(value: Color): string {
-		return ColorConverter.toHexRgbString(value);
+		return this.stringifier_(value);
 	}
 }

--- a/src/main/js/parser/string-color-test.ts
+++ b/src/main/js/parser/string-color-test.ts
@@ -1,9 +1,9 @@
 import {assert} from 'chai';
 import {describe, describe as context, it} from 'mocha';
 
-import {getNotation, StringColorParser} from './string-color';
+import * as StringColorParser from './string-color';
 
-describe(StringColorParser.name, () => {
+describe('StringColorParser', () => {
 	[
 		{
 			expected: {r: 0x11, g: 0x22, b: 0x33},
@@ -31,7 +31,7 @@ describe(StringColorParser.name, () => {
 		testCase.inputs.forEach((input) => {
 			context(`when ${JSON.stringify(input)}`, () => {
 				it(`it should parse as ${JSON.stringify(testCase.expected)}`, () => {
-					const actual = StringColorParser(input);
+					const actual = StringColorParser.CompositeParser(input);
 					assert.deepStrictEqual(
 						actual && actual.toRgbObject(),
 						testCase.expected,
@@ -44,7 +44,7 @@ describe(StringColorParser.name, () => {
 	['foobar', '#eeffgg', 'rgb(123, 234, ..5)', 'rgb(123, 234, xyz)'].forEach(
 		(text) => {
 			it(`should not parse invalid string '${text}'`, () => {
-				assert.strictEqual(StringColorParser(text), null);
+				assert.strictEqual(StringColorParser.CompositeParser(text), null);
 			});
 		},
 	);
@@ -67,7 +67,7 @@ describe(StringColorParser.name, () => {
 			it(`it should detect notation as ${JSON.stringify(
 				testCase.expected,
 			)}`, () => {
-				const actual = getNotation(testCase.input);
+				const actual = StringColorParser.getNotation(testCase.input);
 				assert.deepStrictEqual(actual, testCase.expected);
 			});
 		});

--- a/src/main/js/parser/string-color-test.ts
+++ b/src/main/js/parser/string-color-test.ts
@@ -7,34 +7,45 @@ describe(StringColorParser.name, () => {
 	[
 		{
 			expected: {r: 0x11, g: 0x22, b: 0x33},
-			input: '#112233',
+			inputs: [
+				'#112233',
+				'rgb(17,34,51)',
+				'rgb(17, 34, 51)',
+				'rgb( 17  ,  34  ,  51 )',
+				'rgb(17.0, 34.0, 51.0)',
+			],
 		},
 		{
 			expected: {r: 0xdd, g: 0xee, b: 0xff},
-			input: '#def',
+			inputs: ['#def', 'rgb(221, 238, 100%)'],
 		},
 		{
 			expected: {r: 0x44, g: 0x55, b: 0x66},
-			input: '456',
+			inputs: ['456'],
 		},
 		{
 			expected: {r: 0x99, g: 0xaa, b: 0xbb},
-			input: '99aabb',
+			inputs: ['99aabb'],
 		},
 	].forEach((testCase) => {
-		context(`when ${JSON.stringify(testCase.input)}`, () => {
-			it(`it should parse as ${JSON.stringify(testCase.expected)}`, () => {
-				const actual = StringColorParser(testCase.input);
-				assert.deepStrictEqual(
-					actual && actual.toRgbObject(),
-					testCase.expected,
-				);
+		testCase.inputs.forEach((input) => {
+			context(`when ${JSON.stringify(input)}`, () => {
+				it(`it should parse as ${JSON.stringify(testCase.expected)}`, () => {
+					const actual = StringColorParser(input);
+					assert.deepStrictEqual(
+						actual && actual.toRgbObject(),
+						testCase.expected,
+					);
+				});
 			});
 		});
 	});
 
-	it('should not parse invalid string', () => {
-		assert.strictEqual(StringColorParser('foobar'), null);
-		assert.strictEqual(StringColorParser('#eeffgg'), null);
-	});
+	['foobar', '#eeffgg', 'rgb(123, 234, ..5)', 'rgb(123, 234, xyz)'].forEach(
+		(text) => {
+			it(`should not parse invalid string '${text}'`, () => {
+				assert.strictEqual(StringColorParser(text), null);
+			});
+		},
+	);
 });

--- a/src/main/js/parser/string-color-test.ts
+++ b/src/main/js/parser/string-color-test.ts
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import {describe, describe as context, it} from 'mocha';
 
-import {StringColorParser} from './string-color';
+import {getNotation, StringColorParser} from './string-color';
 
 describe(StringColorParser.name, () => {
 	[
@@ -48,4 +48,28 @@ describe(StringColorParser.name, () => {
 			});
 		},
 	);
+
+	[
+		{
+			expected: 'hex.rgb',
+			input: '#009aff',
+		},
+		{
+			expected: 'func.rgb',
+			input: 'rgb(17,34,51)',
+		},
+		{
+			expected: null,
+			input: 'foobar',
+		},
+	].forEach((testCase) => {
+		context(`when ${JSON.stringify(testCase.input)}`, () => {
+			it(`it should detect notation as ${JSON.stringify(
+				testCase.expected,
+			)}`, () => {
+				const actual = getNotation(testCase.input);
+				assert.deepStrictEqual(actual, testCase.expected);
+			});
+		});
+	});
 });

--- a/src/main/js/parser/string-color.ts
+++ b/src/main/js/parser/string-color.ts
@@ -1,7 +1,7 @@
 import {Color} from '../model/color';
 import {Parser} from './parser';
 
-type StringColorNotation = 'hex.rgb' | 'func.rgb';
+export type StringColorNotation = 'hex.rgb' | 'func.rgb';
 
 function parseCssNumberOrPercentage(text: string, maxValue: number): number {
 	const m = text.match(/^(.+)%$/);
@@ -63,7 +63,7 @@ const NOTATION_TO_PARSER_MAP: {
 /**
  * @hidden
  */
-export const StringColorParser: Parser<string, Color> = (
+export const CompositeParser: Parser<string, Color> = (
 	text: string,
 ): Color | null => {
 	const notations: StringColorNotation[] = Object.keys(

--- a/src/main/js/parser/string-color.ts
+++ b/src/main/js/parser/string-color.ts
@@ -1,40 +1,35 @@
 import {Color} from '../model/color';
 import {Parser} from './parser';
 
-const SUB_PARSERS: Parser<string, Color>[] = [
-	// #aabbcc
-	(text: string): Color | null => {
-		const matches = text.match(
+type ColorParserId = 'hex.rrggbb';
+
+const ID_TO_PARSER_MAP: {[id in ColorParserId]: Parser<string, Color>} = {
+	'hex.rrggbb': (text: string): Color | null => {
+		const mRrggbb = text.match(/^#?([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])$/);
+		if (mRrggbb) {
+			return new Color(
+				[
+					parseInt(mRrggbb[1] + mRrggbb[1], 16),
+					parseInt(mRrggbb[2] + mRrggbb[2], 16),
+					parseInt(mRrggbb[3] + mRrggbb[3], 16),
+				],
+				'rgb',
+			);
+		}
+
+		const mRgb = text.match(
 			/^#?([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/,
 		);
-		if (!matches) {
-			return null;
+		if (mRgb) {
+			return new Color(
+				[parseInt(mRgb[1], 16), parseInt(mRgb[2], 16), parseInt(mRgb[3], 16)],
+				'rgb',
+			);
 		}
-		return new Color(
-			[
-				parseInt(matches[1], 16),
-				parseInt(matches[2], 16),
-				parseInt(matches[3], 16),
-			],
-			'rgb',
-		);
+
+		return null;
 	},
-	// #abc
-	(text: string): Color | null => {
-		const matches = text.match(/^#?([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])$/);
-		if (!matches) {
-			return null;
-		}
-		return new Color(
-			[
-				parseInt(matches[1] + matches[1], 16),
-				parseInt(matches[2] + matches[2], 16),
-				parseInt(matches[3] + matches[3], 16),
-			],
-			'rgb',
-		);
-	},
-];
+};
 
 /**
  * @hidden
@@ -42,7 +37,9 @@ const SUB_PARSERS: Parser<string, Color>[] = [
 export const StringColorParser: Parser<string, Color> = (
 	text: string,
 ): Color | null => {
-	return SUB_PARSERS.reduce((result: Color | null, subparser) => {
+	const ids: ColorParserId[] = Object.keys(ID_TO_PARSER_MAP) as ColorParserId[];
+	return ids.reduce((result: Color | null, id) => {
+		const subparser = ID_TO_PARSER_MAP[id];
 		return result ? result : subparser(text);
 	}, null);
 };

--- a/src/main/js/parser/string-color.ts
+++ b/src/main/js/parser/string-color.ts
@@ -1,7 +1,7 @@
 import {Color} from '../model/color';
 import {Parser} from './parser';
 
-type ColorParserId = 'hex.rgb' | 'func.rgb';
+type StringColorNotation = 'hex.rgb' | 'func.rgb';
 
 function parseCssNumberOrPercentage(text: string, maxValue: number): number {
 	const m = text.match(/^(.+)%$/);
@@ -11,7 +11,9 @@ function parseCssNumberOrPercentage(text: string, maxValue: number): number {
 	return Math.min(parseFloat(m[1]) * 0.01 * maxValue, maxValue);
 }
 
-const ID_TO_PARSER_MAP: {[id in ColorParserId]: Parser<string, Color>} = {
+const NOTATION_TO_PARSER_MAP: {
+	[notation in StringColorNotation]: Parser<string, Color>;
+} = {
 	'func.rgb': (text) => {
 		const m = text.match(
 			/^rgb\(\s*([0-9A-Fa-f.]+%?)\s*,\s*([0-9A-Fa-f.]+%?)\s*,\s*([0-9A-Fa-f.]+%?)\s*\)$/,
@@ -64,9 +66,24 @@ const ID_TO_PARSER_MAP: {[id in ColorParserId]: Parser<string, Color>} = {
 export const StringColorParser: Parser<string, Color> = (
 	text: string,
 ): Color | null => {
-	const ids: ColorParserId[] = Object.keys(ID_TO_PARSER_MAP) as ColorParserId[];
-	return ids.reduce((result: Color | null, id) => {
-		const subparser = ID_TO_PARSER_MAP[id];
+	const notations: StringColorNotation[] = Object.keys(
+		NOTATION_TO_PARSER_MAP,
+	) as StringColorNotation[];
+	return notations.reduce((result: Color | null, notation) => {
+		const subparser = NOTATION_TO_PARSER_MAP[notation];
 		return result ? result : subparser(text);
 	}, null);
 };
+
+export function getNotation(text: string): StringColorNotation | null {
+	const notations: StringColorNotation[] = Object.keys(
+		NOTATION_TO_PARSER_MAP,
+	) as StringColorNotation[];
+	return notations.reduce((result: StringColorNotation | null, notation) => {
+		if (result) {
+			return result;
+		}
+		const subparser = NOTATION_TO_PARSER_MAP[notation];
+		return subparser(text) ? notation : null;
+	}, null);
+}

--- a/src/main/js/view/input/color-swatch-text.ts
+++ b/src/main/js/view/input/color-swatch-text.ts
@@ -17,8 +17,8 @@ const className = ClassName('cswtxt', 'input');
  * @hidden
  */
 export class ColorSwatchTextInputView extends View implements InputView<Color> {
-	private swatchInputView_: ColorSwatchInputView;
-	private textInputView_: TextInputView<Color>;
+	public readonly textInputView: TextInputView<Color>;
+	private readonly swatchInputView_: ColorSwatchInputView;
 
 	constructor(document: Document, config: Config) {
 		super(document);
@@ -33,23 +33,23 @@ export class ColorSwatchTextInputView extends View implements InputView<Color> {
 
 		const textElem = document.createElement('div');
 		textElem.classList.add(className('t'));
-		this.textInputView_ = config.textInputView;
-		textElem.appendChild(this.textInputView_.element);
+		this.textInputView = config.textInputView;
+		textElem.appendChild(this.textInputView.element);
 		this.element.appendChild(textElem);
 	}
 
 	get value(): InputValue<Color> {
-		return this.textInputView_.value;
+		return this.textInputView.value;
 	}
 
 	public dispose(): void {
 		this.swatchInputView_.dispose();
-		this.textInputView_.dispose();
+		this.textInputView.dispose();
 		super.dispose();
 	}
 
 	public update(): void {
 		this.swatchInputView_.update();
-		this.textInputView_.update();
+		this.textInputView.update();
 	}
 }

--- a/src/main/js/view/input/color-swatch.ts
+++ b/src/main/js/view/input/color-swatch.ts
@@ -78,7 +78,9 @@ export class ColorSwatchInputView extends View implements InputView<Color> {
 		}
 
 		const value = this.value.rawValue;
-		this.swatchElem_.style.backgroundColor = ColorConverter.toString(value);
+		this.swatchElem_.style.backgroundColor = ColorConverter.toHexRgbString(
+			value,
+		);
 	}
 
 	private onValueChange_(): void {

--- a/src/main/js/view/monitor/color-swatch.ts
+++ b/src/main/js/view/monitor/color-swatch.ts
@@ -45,7 +45,7 @@ export class ColorSwatchMonitorView extends View implements MonitorView<Color> {
 		const values = this.value.rawValues;
 		this.swatchElem_.style.backgroundColor =
 			values.length > 0
-				? ColorConverter.toString(values[values.length - 1])
+				? ColorConverter.toHexRgbString(values[values.length - 1])
 				: '';
 	}
 


### PR DESCRIPTION
Tweakpane now can tweak a color with functional notation: `rgb(r, g, b)`.

![image](https://user-images.githubusercontent.com/602961/72989651-06b47c80-3e32-11ea-993c-5e6d3bca20b7.png)
