### PR TITLE
Fix unexpected folder padding, #31

### DIFF
--- a/src/main/js/controller/folder.ts
+++ b/src/main/js/controller/folder.ts
@@ -76,7 +76,7 @@ export class FolderController {
 			DomUtil.forceReflow(elem);
 
 			// Compute height
-			height = elem.getBoundingClientRect().height;
+			height = elem.clientHeight;
 
 			// Restore expanded
 			this.folder.expanded = expanded;


### PR DESCRIPTION
`Element.getBoundingClientRect()` returns scaled bounds so used `clientHeight` instead.