### PR TITLE
Fix bug that RootApi cannot handle fold event of subfolders

### DIFF
--- a/src/main/js/api/event-handler-adapters.ts
+++ b/src/main/js/api/event-handler-adapters.ts
@@ -1,6 +1,6 @@
 import {InputBinding, InputBindingEvents} from '../binding/input';
 import {MonitorBinding, MonitorBindingEvents} from '../binding/monitor';
-import {Folder} from '../model/folder';
+import {Folder, FolderEvents} from '../model/folder';
 import {
 	UiControllerList,
 	UiControllerListEvents,
@@ -81,11 +81,14 @@ export function folder({
 		);
 	}
 	if (eventName === 'fold') {
-		uiControllerList.emitter.on('fold', () => {
-			handler();
-		});
-		folder?.emitter.on('change', () => {
-			handler();
+		uiControllerList.emitter.on(
+			'fold',
+			(ev: UiControllerListEvents['fold']) => {
+				handler(ev.expanded);
+			},
+		);
+		folder?.emitter.on('change', (ev: FolderEvents['fold']) => {
+			handler(ev.expanded);
 		});
 	}
 }

--- a/src/main/js/api/root-ui-test.ts
+++ b/src/main/js/api/root-ui-test.ts
@@ -11,9 +11,10 @@ import {TestUtil} from '../misc/test-util';
 import {Disposable} from '../model/disposable';
 import {RootApi} from './root';
 
-function createApi(): RootApi {
+function createApi(title?: string): RootApi {
 	const c = new RootController(TestUtil.createWindow().document, {
 		disposable: new Disposable(),
+		title: title,
 	});
 	return new RootApi(c);
 }
@@ -51,6 +52,34 @@ describe(RootApi.name, () => {
 
 		const cs = api.controller.uiControllerList.items;
 		assert.instanceOf(cs[cs.length - 1], SeparatorController);
+	});
+
+	it('should handle root folder events', (done) => {
+		const api = createApi('pane');
+
+		api.on('fold', (expanded) => {
+			assert.strictEqual(expanded, false);
+			done();
+		});
+
+		const f = api.controller.folder;
+		if (!f) {
+			throw new Error('Root folder not found');
+		}
+		f.expanded = false;
+	});
+
+	it('should handle folder events', (done) => {
+		const api = createApi();
+		const f = api.addFolder({
+			title: 'folder',
+		});
+
+		api.on('fold', (expanded) => {
+			assert.strictEqual(expanded, false);
+			done();
+		});
+		f.expanded = false;
 	});
 
 	[

--- a/src/main/js/model/folder.ts
+++ b/src/main/js/model/folder.ts
@@ -5,6 +5,7 @@ import {Emitter, EventTypeMap} from '../misc/emitter';
  */
 export interface FolderEvents extends EventTypeMap {
 	change: {
+		expanded: boolean;
 		sender: Folder;
 	};
 }
@@ -34,6 +35,7 @@ export class Folder {
 		if (changed) {
 			this.expanded_ = expanded;
 			this.emitter.emit('change', {
+				expanded: expanded,
 				sender: this,
 			});
 		}
@@ -48,6 +50,7 @@ export class Folder {
 		if (changed) {
 			this.expandedHeight_ = expandedHeight;
 			this.emitter.emit('change', {
+				expanded: this.expanded_,
 				sender: this,
 			});
 		}


### PR DESCRIPTION
```js
it('should handle folder events', (done) => {
  const api = createApi();
  const f = api.addFolder({
    title: 'folder',
  });

  api.on('fold', (expanded) => {
    assert.strictEqual(expanded, false);
    done();
  });
  f.expanded = false;
});
```