### PR TITLE
Add missing dispose

### DIFF
--- a/src/main/js/api/button.ts
+++ b/src/main/js/api/button.ts
@@ -1,10 +1,11 @@
 import {ButtonController} from '../controller/button';
+import {ComponentApi} from './component-api';
 
 interface ButtonApiEventHandlers {
 	click: () => void;
 }
 
-export class ButtonApi {
+export class ButtonApi implements ComponentApi {
 	/**
 	 * @hidden
 	 */

--- a/src/main/js/api/component-api.ts
+++ b/src/main/js/api/component-api.ts
@@ -1,0 +1,7 @@
+/**
+ * @hidden
+ */
+export interface ComponentApi {
+	hidden: boolean;
+	dispose(): void;
+}

--- a/src/main/js/api/folder.ts
+++ b/src/main/js/api/folder.ts
@@ -6,6 +6,7 @@ import {SeparatorController} from '../controller/separator';
 import {Target} from '../model/target';
 import {ViewModel} from '../model/view-model';
 import {ButtonApi} from './button';
+import {ComponentApi} from './component-api';
 import * as EventHandlerAdapters from './event-handler-adapters';
 import {InputBindingApi} from './input-binding';
 import {MonitorBindingApi} from './monitor-binding';
@@ -23,7 +24,7 @@ interface FolderApiEventHandlers {
 	update: (value: unknown) => void;
 }
 
-export class FolderApi {
+export class FolderApi implements ComponentApi {
 	/**
 	 * @hidden
 	 */

--- a/src/main/js/api/input-binding.ts
+++ b/src/main/js/api/input-binding.ts
@@ -31,6 +31,10 @@ export class InputBindingApi<In, Out> {
 		this.controller.viewModel.hidden = hidden;
 	}
 
+	public dispose(): void {
+		this.controller.viewModel.dispose();
+	}
+
 	public on<EventName extends keyof InputBindingApiEventHandlers>(
 		eventName: EventName,
 		handler: InputBindingApiEventHandlers[EventName],

--- a/src/main/js/api/input-binding.ts
+++ b/src/main/js/api/input-binding.ts
@@ -1,4 +1,5 @@
 import {InputBindingController} from '../controller/input-binding';
+import {ComponentApi} from './component-api';
 import * as HandlerAdapters from './event-handler-adapters';
 
 interface InputBindingApiEventHandlers {
@@ -10,7 +11,7 @@ interface InputBindingApiEventHandlers {
  * @param In The type inner Tweakpane.
  * @param Out The type outer Tweakpane (= parameter object).
  */
-export class InputBindingApi<In, Out> {
+export class InputBindingApi<In, Out> implements ComponentApi {
 	/**
 	 * @hidden
 	 */

--- a/src/main/js/api/monitor-binding.ts
+++ b/src/main/js/api/monitor-binding.ts
@@ -1,4 +1,5 @@
 import {MonitorBindingController} from '../controller/monitor-binding';
+import {ComponentApi} from './component-api';
 import * as EventHandlerAdapters from './event-handler-adapters';
 
 interface MonitorBindingApiEventHandlers {
@@ -8,7 +9,7 @@ interface MonitorBindingApiEventHandlers {
 /**
  * The API for the monitor binding between the parameter and the pane.
  */
-export class MonitorBindingApi<In> {
+export class MonitorBindingApi<In> implements ComponentApi {
 	/**
 	 * @hidden
 	 */

--- a/src/main/js/api/root-input-test.ts
+++ b/src/main/js/api/root-input-test.ts
@@ -124,4 +124,15 @@ describe(RootApi.name, () => {
 			});
 		});
 	});
+
+	it('should dispose input', () => {
+		const PARAMS = {foo: 1};
+		const api = createApi();
+		const bapi = api.addInput(PARAMS, 'foo');
+		bapi.dispose();
+		assert.strictEqual(
+			api.controller.view.element.querySelector('.tp-lblv'),
+			null,
+		);
+	});
 });

--- a/src/main/js/api/root.ts
+++ b/src/main/js/api/root.ts
@@ -10,6 +10,7 @@ import * as UiUtil from '../controller/ui-util';
 import {Target} from '../model/target';
 import {ViewModel} from '../model/view-model';
 import {ButtonApi} from './button';
+import {ComponentApi} from './component-api';
 import * as EventHandlerAdapters from './event-handler-adapters';
 import {FolderApi} from './folder';
 import {InputBindingApi} from './input-binding';
@@ -40,7 +41,7 @@ interface RootApiEventHandlers {
  *
  * See [[TweakpaneConfig]] interface for available options.
  */
-export class RootApi {
+export class RootApi implements ComponentApi {
 	/**
 	 * @hidden
 	 */

--- a/src/main/js/api/separator.ts
+++ b/src/main/js/api/separator.ts
@@ -1,6 +1,7 @@
 import {SeparatorController} from '../controller/separator';
+import {ComponentApi} from './component-api';
 
-export class SeparatorApi {
+export class SeparatorApi implements ComponentApi {
 	/**
 	 * @hidden
 	 */


### PR DESCRIPTION
Added missing `dispose()` to input binding API. Also added `ComponentAPI` interface for the future update.