### PR TITLE
Replace `KeyboardEvent.keyCode` with `key`

### DIFF
--- a/lib/plugin/common/ui.ts
+++ b/lib/plugin/common/ui.ts
@@ -25,9 +25,9 @@ export function getStepForKey(baseStep: number, keys: StepKeys): number {
 export function getVerticalStepKeys(ev: KeyboardEvent): StepKeys {
 	return {
 		altKey: ev.altKey,
-		downKey: ev.keyCode === 40,
+		downKey: ev.key === 'ArrowDown',
 		shiftKey: ev.shiftKey,
-		upKey: ev.keyCode === 38,
+		upKey: ev.key === 'ArrowUp',
 	};
 }
 
@@ -37,22 +37,22 @@ export function getVerticalStepKeys(ev: KeyboardEvent): StepKeys {
 export function getHorizontalStepKeys(ev: KeyboardEvent): StepKeys {
 	return {
 		altKey: ev.altKey,
-		downKey: ev.keyCode === 37,
+		downKey: ev.key === 'ArrowLeft',
 		shiftKey: ev.shiftKey,
-		upKey: ev.keyCode === 39,
+		upKey: ev.key === 'ArrowRight',
 	};
 }
 
 /**
  * @hidden
  */
-export function isVerticalArrowKey(keyCode: number): boolean {
-	return keyCode === 38 || keyCode === 40;
+export function isVerticalArrowKey(key: string): boolean {
+	return key === 'ArrowUp' || key === 'ArrowDown';
 }
 
 /**
  * @hidden
  */
-export function isArrowKey(keyCode: number): boolean {
-	return isVerticalArrowKey(keyCode) || keyCode === 37 || keyCode === 39;
+export function isArrowKey(key: string): boolean {
+	return isVerticalArrowKey(key) || key === 'ArrowLeft' || key === 'ArrowRight';
 }

--- a/lib/plugin/input-bindings/color/controller/color-picker.ts
+++ b/lib/plugin/input-bindings/color/controller/color-picker.ts
@@ -144,7 +144,7 @@ export class ColorPickerController implements ValueController<Color> {
 	}
 
 	private onKeyDown_(ev: KeyboardEvent): void {
-		if (ev.keyCode === 27) {
+		if (ev.key === 'Escape') {
 			this.foldable.expanded = false;
 		}
 	}

--- a/lib/plugin/input-bindings/color/controller/color-text-test.ts
+++ b/lib/plugin/input-bindings/color/controller/color-text-test.ts
@@ -5,33 +5,13 @@ import {TestUtil} from '../../../../misc/test-util';
 import {parseNumber} from '../../../common/converter/number';
 import {Value} from '../../../common/model/value';
 import {createViewProps} from '../../../common/model/view-props';
-import {Color, RgbaColorObject} from '../model/color';
+import {Color} from '../model/color';
+import {ColorComponents3} from '../model/color-model';
 import {PickedColor} from '../model/picked-color';
 import {ColorTextController} from './color-text';
 
-interface ChangeTestCase {
-	expected: RgbaColorObject;
-	params: {
-		components: [number, number, number];
-		index: number;
-		value: string;
-	};
-}
-
-interface KeydownTestCase {
-	expected: RgbaColorObject;
-	params: {
-		components: [number, number, number];
-		index: number;
-		keys: {
-			code: number;
-			shift: boolean;
-		};
-	};
-}
-
 describe(ColorTextController.name, () => {
-	([
+	[
 		{
 			expected: {r: 123, g: 0, b: 0, a: 1},
 			params: {
@@ -56,12 +36,14 @@ describe(ColorTextController.name, () => {
 				value: '0',
 			},
 		},
-	] as ChangeTestCase[]).forEach((testCase) => {
+	].forEach((testCase) => {
 		context(`when params = ${JSON.stringify(testCase.params)}`, () => {
 			it(`should change component values to ${JSON.stringify(
 				testCase.expected,
 			)}`, (done) => {
-				const value = new Value(new Color(testCase.params.components, 'rgb'));
+				const value = new Value(
+					new Color(testCase.params.components as ColorComponents3, 'rgb'),
+				);
 				value.emitter.on('change', () => {
 					assert.deepStrictEqual(
 						value.rawValue.toRgbaObject(),
@@ -85,14 +67,14 @@ describe(ColorTextController.name, () => {
 		});
 	});
 
-	([
+	[
 		{
 			expected: {r: 1, g: 0, b: 0, a: 1},
 			params: {
 				components: [0, 0, 0],
 				index: 0,
 				keys: {
-					code: 38,
+					key: 'ArrowUp',
 					shift: false,
 				},
 			},
@@ -103,7 +85,7 @@ describe(ColorTextController.name, () => {
 				components: [0, 100, 0],
 				index: 1,
 				keys: {
-					code: 40,
+					key: 'ArrowDown',
 					shift: false,
 				},
 			},
@@ -114,17 +96,19 @@ describe(ColorTextController.name, () => {
 				components: [0, 0, 200],
 				index: 2,
 				keys: {
-					code: 38,
+					key: 'ArrowUp',
 					shift: true,
 				},
 			},
 		},
-	] as KeydownTestCase[]).forEach((testCase) => {
+	].forEach((testCase) => {
 		context(`when params = ${JSON.stringify(testCase.params)}`, () => {
 			it(`should change component values to ${JSON.stringify(
 				testCase.expected,
 			)}`, (done) => {
-				const value = new Value(new Color(testCase.params.components, 'rgb'));
+				const value = new Value(
+					new Color(testCase.params.components as ColorComponents3, 'rgb'),
+				);
 				value.emitter.on('change', () => {
 					assert.deepStrictEqual(
 						value.rawValue.toRgbaObject(),
@@ -144,7 +128,7 @@ describe(ColorTextController.name, () => {
 				const inputElem = c.view.textViews[testCase.params.index].inputElement;
 				inputElem.dispatchEvent(
 					TestUtil.createKeyboardEvent(win, 'keydown', {
-						keyCode: testCase.params.keys.code,
+						key: testCase.params.keys.key,
 						shiftKey: !!testCase.params.keys.shift,
 					}),
 				);

--- a/lib/plugin/input-bindings/color/controller/sv-palette.ts
+++ b/lib/plugin/input-bindings/color/controller/sv-palette.ts
@@ -79,7 +79,7 @@ export class SvPaletteController implements ValueController<Color> {
 	}
 
 	private onKeyDown_(ev: KeyboardEvent): void {
-		if (isArrowKey(ev.keyCode)) {
+		if (isArrowKey(ev.key)) {
 			ev.preventDefault();
 		}
 

--- a/lib/plugin/input-bindings/common/controller/point-nd-text-test.ts
+++ b/lib/plugin/input-bindings/common/controller/point-nd-text-test.ts
@@ -42,7 +42,7 @@ describe(PointNdTextController.name, () => {
 
 		c.view.textViews[1].inputElement.dispatchEvent(
 			TestUtil.createKeyboardEvent(win, 'keydown', {
-				keyCode: 38,
+				key: 'ArrowUp',
 				shiftKey: true,
 			}),
 		);

--- a/lib/plugin/input-bindings/number/controller/number-text-test.ts
+++ b/lib/plugin/input-bindings/number/controller/number-text-test.ts
@@ -25,7 +25,7 @@ describe(NumberTextController.name, () => {
 
 		c.view.inputElement.dispatchEvent(
 			TestUtil.createKeyboardEvent(win, 'keydown', {
-				keyCode: 38,
+				key: 'ArrowUp',
 				shiftKey: true,
 			}),
 		);

--- a/lib/plugin/input-bindings/point-2d/controller/point-2d-pad.ts
+++ b/lib/plugin/input-bindings/point-2d/controller/point-2d-pad.ts
@@ -108,7 +108,7 @@ export class Point2dPadController implements ValueController<Point2d> {
 	}
 
 	private onPadKeyDown_(ev: KeyboardEvent): void {
-		if (isArrowKey(ev.keyCode)) {
+		if (isArrowKey(ev.key)) {
 			ev.preventDefault();
 		}
 
@@ -141,7 +141,7 @@ export class Point2dPadController implements ValueController<Point2d> {
 	}
 
 	private onKeyDown_(ev: KeyboardEvent): void {
-		if (ev.keyCode === 27) {
+		if (ev.key === 'Escape') {
 			this.foldable.expanded = false;
 		}
 	}


### PR DESCRIPTION
`keyCode` is deprecated:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode