### PR TITLE
Resolve core types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"strict": true,
-		"target": "ES6"
+		"target": "ES6",
+		"baseUrl": ".",
+		"paths": {
+			"@tweakpane/core": ["packages/core/src"]
+		}
 	}
 }


### PR DESCRIPTION
## Issue
When using Tweakpane, I do not get all of the types I would expect from the documentation.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/15187179/172053077-47e1cc5e-ff59-41ee-9aca-65a4678a5a82.png">

This `addInput` method comes from `Folder` which is in the core types. It seems that these core types are not being bundled with the package because TypeScript does not know how to resolve them.

## Resolution

This PR shows TypeScript where the types can be found by using the `paths` property of the TS Config

Note: I admittedly could not test actually building the package and importing the local build, because I couldn't install the dependencies, so I'm not 100% sure this works, but it did resolve import errors internally in `packages/tweakpane/src/main/ts/pane/pane.ts`.