### PR TITLE
Add `tag` to binding APIs

### DIFF
--- a/packages/core/src/blade/binding/api/binding.ts
+++ b/packages/core/src/blade/binding/api/binding.ts
@@ -49,6 +49,17 @@ export class BindingApi<
 		return this.controller_.value.binding.target.key;
 	}
 
+	/**
+	 * The generic tag with many uses.
+	 */
+	get tag(): string | undefined {
+		return this.controller_.tag;
+	}
+
+	set tag(tag: string | undefined) {
+		this.controller_.tag = tag;
+	}
+
 	public on<EventName extends keyof BindingApiEvents<Ex>>(
 		eventName: EventName,
 		handler: (ev: BindingApiEvents<Ex>[EventName]) => void,

--- a/packages/core/src/blade/binding/api/input-binding-test.ts
+++ b/packages/core/src/blade/binding/api/input-binding-test.ts
@@ -87,6 +87,7 @@ describe('InputBindingApi', () => {
 		const api = createApi(new BindingTarget(PARAMS, 'foo'));
 		assertInitialState(api);
 		assert.strictEqual(api.label, 'label');
+		assert.strictEqual(api.tag, undefined);
 	});
 
 	it('should update properties', () => {
@@ -98,5 +99,8 @@ describe('InputBindingApi', () => {
 
 		api.label = 'changed';
 		assert.strictEqual(api.label, 'changed');
+
+		api.tag = 'tag';
+		assert.strictEqual(api.tag, 'tag');
 	});
 });

--- a/packages/core/src/blade/binding/api/monitor-binding-test.ts
+++ b/packages/core/src/blade/binding/api/monitor-binding-test.ts
@@ -17,8 +17,8 @@ import {SingleLogController} from '../../../monitor-binding/common/controller/si
 import {assertInitialState, assertUpdates} from '../../common/api/test-util';
 import {TpChangeEvent} from '../../common/api/tp-event';
 import {createBlade} from '../../common/model/blade';
-import {LabeledValueController} from '../../label/controller/value-label';
 import {LabelPropsObject} from '../../label/view/label';
+import {BindingController} from '../controller/binding';
 import {MonitorBindingController} from '../controller/monitor-binding';
 import {BindingApi} from './binding';
 import {MonitorBindingApi} from './monitor-binding';
@@ -38,7 +38,7 @@ function createApi(target: BindingTarget): MonitorBindingApi<number> {
 		value: v,
 		viewProps: ViewProps.create(),
 	});
-	const bc = new LabeledValueController(doc, {
+	const bc = new BindingController(doc, {
 		blade: createBlade(),
 		props: ValueMap.fromObject<LabelPropsObject>({
 			label: 'label',

--- a/packages/core/src/blade/binding/controller/binding-test.ts
+++ b/packages/core/src/blade/binding/controller/binding-test.ts
@@ -5,67 +5,94 @@ import {ReadWriteBinding} from '../../../common/binding/read-write';
 import {BindingTarget} from '../../../common/binding/target';
 import {InputBindingValue} from '../../../common/binding/value/input-binding';
 import {TextController} from '../../../common/controller/text';
-import {
-	createNumberFormatter,
-	numberFromUnknown,
-	parseNumber,
-} from '../../../common/converter/number';
 import {ValueMap} from '../../../common/model/value-map';
 import {createValue} from '../../../common/model/values';
 import {ViewProps} from '../../../common/model/view-props';
-import {writePrimitive} from '../../../common/primitive';
+import {colorFromRgbNumber} from '../../../input-binding/color/converter/color-number';
+import {
+	colorToHexRgbString,
+	createColorStringParser,
+} from '../../../input-binding/color/converter/color-string';
+import {createColorNumberWriter} from '../../../input-binding/color/converter/writer';
+import {IntColor} from '../../../input-binding/color/model/int-color';
 import {createTestWindow} from '../../../misc/dom-test-util';
 import {createBlade} from '../../common/model/blade';
 import {LabelPropsObject} from '../../label/view/label';
 import {BindingController} from './binding';
+import {InputBindingController} from './input-binding';
 
 function createController(
 	doc: Document,
 	config: {
-		tag?: string | undefined;
+		tag?: string;
+		value: number;
 	},
 ) {
-	const obj = {foo: 0};
+	const obj = {foo: config.value};
 	const binding = new ReadWriteBinding({
-		reader: numberFromUnknown,
+		reader: colorFromRgbNumber,
 		target: new BindingTarget(obj, 'foo'),
-		writer: writePrimitive,
+		writer: createColorNumberWriter(false),
 	});
-	const value = new InputBindingValue(createValue(0), binding);
-	const vc = new TextController<number>(doc, {
-		parser: parseNumber,
+	const value = new InputBindingValue(
+		createValue(new IntColor([0, 0, 0], 'rgb')),
+		binding,
+	);
+	const vc = new TextController<IntColor>(doc, {
+		parser: createColorStringParser('int'),
 		props: ValueMap.fromObject({
-			formatter: createNumberFormatter(0),
+			formatter: (v) => colorToHexRgbString(v, '0x'),
 		}),
 		value: value,
 		viewProps: ViewProps.create(),
 	});
-	return new BindingController<number>(doc, {
-		blade: createBlade(),
-		props: ValueMap.fromObject<LabelPropsObject>({
-			label: 'foo',
-		}),
-		tag: config.tag,
+	return {
 		value: value,
 		valueController: vc,
-	});
+		controller: new InputBindingController<IntColor>(doc, {
+			blade: createBlade(),
+			props: ValueMap.fromObject<LabelPropsObject>({
+				label: 'foo',
+			}),
+			tag: config.tag,
+			value: value,
+			valueController: vc,
+		}),
+	};
 }
 
 describe(BindingController.name, () => {
+	it('should get properties', () => {
+		const doc = createTestWindow().document;
+		const {
+			value,
+			valueController: vc,
+			controller: bc,
+		} = createController(doc, {
+			value: 0x112233,
+		});
+
+		assert.strictEqual(bc.value, value);
+		assert.strictEqual(bc.valueController, vc);
+	});
+
 	it('should export state', () => {
 		const doc = createTestWindow().document;
-		const c = createController(doc, {
+		const {controller: c} = createController(doc, {
 			tag: 'foo',
+			value: 0x112233,
 		});
 		const state = c.exportState();
 
 		assert.strictEqual(state.tag, 'foo');
+		assert.strictEqual(state.value, 0x112233);
 	});
 
 	it('should import state', () => {
 		const doc = createTestWindow().document;
-		const c = createController(doc, {
+		const {controller: c} = createController(doc, {
 			tag: 'foo',
+			value: 0x112233,
 		});
 
 		assert.strictEqual(

--- a/packages/core/src/blade/binding/controller/binding-test.ts
+++ b/packages/core/src/blade/binding/controller/binding-test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import {describe, it} from 'mocha';
+
+import {ReadWriteBinding} from '../../../common/binding/read-write';
+import {BindingTarget} from '../../../common/binding/target';
+import {InputBindingValue} from '../../../common/binding/value/input-binding';
+import {TextController} from '../../../common/controller/text';
+import {
+	createNumberFormatter,
+	numberFromUnknown,
+	parseNumber,
+} from '../../../common/converter/number';
+import {ValueMap} from '../../../common/model/value-map';
+import {createValue} from '../../../common/model/values';
+import {ViewProps} from '../../../common/model/view-props';
+import {writePrimitive} from '../../../common/primitive';
+import {createTestWindow} from '../../../misc/dom-test-util';
+import {createBlade} from '../../common/model/blade';
+import {LabelPropsObject} from '../../label/view/label';
+import {BindingController} from './binding';
+
+function createController(
+	doc: Document,
+	config: {
+		tag?: string | undefined;
+	},
+) {
+	const obj = {foo: 0};
+	const binding = new ReadWriteBinding({
+		reader: numberFromUnknown,
+		target: new BindingTarget(obj, 'foo'),
+		writer: writePrimitive,
+	});
+	const value = new InputBindingValue(createValue(0), binding);
+	const vc = new TextController<number>(doc, {
+		parser: parseNumber,
+		props: ValueMap.fromObject({
+			formatter: createNumberFormatter(0),
+		}),
+		value: value,
+		viewProps: ViewProps.create(),
+	});
+	return new BindingController<number>(doc, {
+		blade: createBlade(),
+		props: ValueMap.fromObject<LabelPropsObject>({
+			label: 'foo',
+		}),
+		tag: config.tag,
+		value: value,
+		valueController: vc,
+	});
+}
+
+describe(BindingController.name, () => {
+	it('should export state', () => {
+		const doc = createTestWindow().document;
+		const c = createController(doc, {
+			tag: 'foo',
+		});
+		const state = c.exportState();
+
+		assert.strictEqual(state.tag, 'foo');
+	});
+
+	it('should import state', () => {
+		const doc = createTestWindow().document;
+		const c = createController(doc, {
+			tag: 'foo',
+		});
+
+		assert.strictEqual(
+			c.importState({
+				disabled: true,
+				hidden: true,
+				label: 'label',
+				tag: 'bar',
+				value: 0,
+			}),
+			true,
+		);
+		assert.strictEqual(c.tag, 'bar');
+	});
+});

--- a/packages/core/src/blade/binding/controller/binding.ts
+++ b/packages/core/src/blade/binding/controller/binding.ts
@@ -4,13 +4,58 @@ import {
 } from '../../../common/binding/value/binding';
 import {ValueController} from '../../../common/controller/value';
 import {BladeController} from '../../common/controller/blade';
+import {
+	BladeState,
+	exportBladeState,
+	importBladeState,
+} from '../../common/controller/blade-state';
 import {isValueBladeController} from '../../common/controller/value-blade';
-import {LabeledValueController} from '../../label/controller/value-label';
+import {
+	LabeledValueConfig,
+	LabeledValueController,
+} from '../../label/controller/value-label';
 
-export type BindingController<
+interface Config<
+	In,
+	Vc extends ValueController<In>,
+	Va extends BindingValue<In>,
+> extends LabeledValueConfig<In, Vc, Va> {
+	tag?: string | undefined;
+}
+
+export class BindingController<
 	In = unknown,
 	Vc extends ValueController<In> = ValueController<In>,
-> = LabeledValueController<In, Vc, BindingValue<In>>;
+	Va extends BindingValue<In> = BindingValue<In>,
+> extends LabeledValueController<In, Vc, Va> {
+	public tag: string | undefined;
+
+	constructor(doc: Document, config: Config<In, Vc, Va>) {
+		super(doc, config);
+
+		this.tag = config.tag;
+	}
+
+	override importState(state: BladeState): boolean {
+		return importBladeState(
+			state,
+			(s) => super.importState(s),
+			(p) => ({
+				tag: p.optional.string,
+			}),
+			(result) => {
+				this.tag = result.tag;
+				return true;
+			},
+		);
+	}
+
+	override exportState(): BladeState {
+		return exportBladeState(() => super.exportState(), {
+			tag: this.tag,
+		});
+	}
+}
 
 export function isBindingController(
 	bc: BladeController,

--- a/packages/core/src/blade/binding/controller/binding.ts
+++ b/packages/core/src/blade/binding/controller/binding.ts
@@ -15,6 +15,14 @@ import {
 	LabeledValueController,
 } from '../../label/controller/value-label';
 
+function excludeValue(state: BladeState): Omit<BladeState, 'value'> {
+	const result = {
+		...state,
+	};
+	delete result.value;
+	return result;
+}
+
 interface Config<
 	In,
 	Vc extends ValueController<In>,
@@ -39,7 +47,9 @@ export class BindingController<
 	override importState(state: BladeState): boolean {
 		return importBladeState(
 			state,
-			(s) => super.importState(s),
+			// Exclude `value` from super.import()
+			// value should be imported with binding
+			(_s) => super.importState(excludeValue(state)),
 			(p) => ({
 				tag: p.optional.string,
 			}),
@@ -52,7 +62,9 @@ export class BindingController<
 
 	override exportState(): BladeState {
 		return exportBladeState(() => super.exportState(), {
+			key: this.value.binding.target.key,
 			tag: this.tag,
+			value: this.value.binding.target.read(),
 		});
 	}
 }

--- a/packages/core/src/blade/binding/controller/input-binding-test.ts
+++ b/packages/core/src/blade/binding/controller/input-binding-test.ts
@@ -33,7 +33,7 @@ function createController(doc: Document) {
 		createValue(new IntColor([0, 0, 0], 'rgb')),
 		binding,
 	);
-	const controller = new TextController<IntColor>(doc, {
+	const vc = new TextController<IntColor>(doc, {
 		parser: createColorStringParser('int'),
 		props: ValueMap.fromObject({
 			formatter: (v) => colorToHexRgbString(v, '0x'),
@@ -41,43 +41,20 @@ function createController(doc: Document) {
 		value: value,
 		viewProps: ViewProps.create(),
 	});
-	return {
-		value: value,
-		valueController: controller,
-		controller: new InputBindingController<IntColor>(doc, {
-			blade: createBlade(),
-			props: ValueMap.fromObject<LabelPropsObject>({
-				label: 'foo',
-			}),
-			value: value,
-			valueController: controller,
+	return new InputBindingController<IntColor>(doc, {
+		blade: createBlade(),
+		props: ValueMap.fromObject<LabelPropsObject>({
+			label: 'foo',
 		}),
-	};
+		value: value,
+		valueController: vc,
+	});
 }
 
 describe(InputBindingController.name, () => {
-	it('should get properties', () => {
-		const doc = createTestWindow().document;
-		const {value, valueController: vc, controller: bc} = createController(doc);
-
-		assert.strictEqual(bc.value, value);
-		assert.strictEqual(bc.valueController, vc);
-	});
-
-	it('should export state', () => {
-		const doc = createTestWindow().document;
-		const {controller: bc} = createController(doc);
-
-		const state = bc.exportState();
-		assert.ok('disabled' in state);
-		assert.ok('hidden' in state);
-		assert.ok('label' in state);
-		assert.strictEqual(state.value, 0x112233);
-	});
-
 	it('should import state', () => {
 		const doc = createTestWindow().document;
-		const {controller: bc} = createController(doc);
+		const bc = createController(doc);
 
 		assert.strictEqual(
 			bc.importState({

--- a/packages/core/src/blade/binding/controller/input-binding.ts
+++ b/packages/core/src/blade/binding/controller/input-binding.ts
@@ -6,19 +6,10 @@ import {ValueController} from '../../../common/controller/value';
 import {BladeController} from '../../common/controller/blade';
 import {
 	BladeState,
-	exportBladeState,
 	importBladeState,
 } from '../../common/controller/blade-state';
 import {isValueBladeController} from '../../common/controller/value-blade';
 import {BindingController} from './binding';
-
-function excludeValue(state: BladeState): Omit<BladeState, 'value'> {
-	const result = {
-		...state,
-	};
-	delete result.value;
-	return result;
-}
 
 export class InputBindingController<
 	In = unknown,
@@ -27,9 +18,7 @@ export class InputBindingController<
 	override importState(state: BladeState): boolean {
 		return importBladeState(
 			state,
-			// Exclude `value` from super.import()
-			// value should be imported with binding
-			(_s) => super.importState(excludeValue(state)),
+			(s) => super.importState(s),
 			(p) => ({
 				value: p.required.raw,
 			}),
@@ -39,13 +28,6 @@ export class InputBindingController<
 				return true;
 			},
 		);
-	}
-
-	override exportState(): BladeState {
-		return exportBladeState(() => super.exportState(), {
-			key: this.value.binding.target.key,
-			value: this.value.binding.target.read(),
-		});
 	}
 }
 

--- a/packages/core/src/blade/binding/controller/input-binding.ts
+++ b/packages/core/src/blade/binding/controller/input-binding.ts
@@ -10,7 +10,7 @@ import {
 	importBladeState,
 } from '../../common/controller/blade-state';
 import {isValueBladeController} from '../../common/controller/value-blade';
-import {LabeledValueController} from '../../label/controller/value-label';
+import {BindingController} from './binding';
 
 function excludeValue(state: BladeState): Omit<BladeState, 'value'> {
 	const result = {
@@ -23,7 +23,7 @@ function excludeValue(state: BladeState): Omit<BladeState, 'value'> {
 export class InputBindingController<
 	In = unknown,
 	Vc extends ValueController<In> = ValueController<In>,
-> extends LabeledValueController<In, Vc, InputBindingValue<In>> {
+> extends BindingController<In, Vc, InputBindingValue<In>> {
 	override importState(state: BladeState): boolean {
 		return importBladeState(
 			state,

--- a/packages/core/src/blade/binding/controller/monitor-binding-test.ts
+++ b/packages/core/src/blade/binding/controller/monitor-binding-test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import {describe, it} from 'mocha';
+
+import {ReadonlyBinding} from '../../../common/binding/readonly';
+import {BindingTarget} from '../../../common/binding/target';
+import {ManualTicker} from '../../../common/binding/ticker/manual';
+import {MonitorBindingValue} from '../../../common/binding/value/monitor-binding';
+import {
+	createNumberFormatter,
+	numberFromUnknown,
+} from '../../../common/converter/number';
+import {ValueMap} from '../../../common/model/value-map';
+import {ViewProps} from '../../../common/model/view-props';
+import {createTestWindow} from '../../../misc/dom-test-util';
+import {SingleLogController} from '../../../monitor-binding/common/controller/single-log';
+import {createBlade} from '../../common/model/blade';
+import {LabelPropsObject} from '../../label/view/label';
+import {BindingController} from './binding';
+import {MonitorBindingController} from './monitor-binding';
+
+function createController(
+	doc: Document,
+	config: {
+		tag?: string;
+		value: number;
+	},
+) {
+	const obj = {foo: config.value};
+	const binding = new ReadonlyBinding({
+		reader: numberFromUnknown,
+		target: new BindingTarget(obj, 'foo'),
+	});
+	const value = new MonitorBindingValue({
+		binding: binding,
+		bufferSize: 1,
+		ticker: new ManualTicker(),
+	});
+	const vc = new SingleLogController(doc, {
+		formatter: createNumberFormatter(1),
+		value: value,
+		viewProps: ViewProps.create(),
+	});
+	return new BindingController(doc, {
+		blade: createBlade(),
+		props: ValueMap.fromObject<LabelPropsObject>({
+			label: 'foo',
+		}),
+		tag: config.tag,
+		value: value,
+		valueController: vc,
+	}) as MonitorBindingController<number>;
+}
+
+describe('MonitorBindingController', () => {
+	it('should export state', () => {
+		const doc = createTestWindow().document;
+		const c = createController(doc, {
+			tag: 'foo',
+			value: 123,
+		});
+		const state = c.exportState();
+
+		assert.strictEqual(state.tag, 'foo');
+		assert.strictEqual(state.value, 123);
+	});
+});

--- a/packages/core/src/blade/binding/controller/monitor-binding.ts
+++ b/packages/core/src/blade/binding/controller/monitor-binding.ts
@@ -7,7 +7,7 @@ import {BufferedValue, TpBuffer} from '../../../common/model/buffered-value';
 import {View} from '../../../common/view/view';
 import {BladeController} from '../../common/controller/blade';
 import {isValueBladeController} from '../../common/controller/value-blade';
-import {LabeledValueController} from '../../label/controller/value-label';
+import {BindingController} from './binding';
 
 export type BufferedValueController<
 	T,
@@ -17,7 +17,7 @@ export type BufferedValueController<
 export type MonitorBindingController<
 	T = unknown,
 	Vc extends BufferedValueController<T> = BufferedValueController<T>,
-> = LabeledValueController<TpBuffer<T>, Vc, MonitorBindingValue<T>>;
+> = BindingController<TpBuffer<T>, Vc, MonitorBindingValue<T>>;
 
 export function isMonitorBindingController(
 	bc: BladeController,

--- a/packages/core/src/blade/common/model/rack-test.ts
+++ b/packages/core/src/blade/common/model/rack-test.ts
@@ -22,6 +22,7 @@ import {CheckboxController} from '../../../input-binding/boolean/controller/chec
 import {createTestWindow} from '../../../misc/dom-test-util';
 import {forceCast} from '../../../misc/type-util';
 import {SingleLogController} from '../../../monitor-binding/common/controller/single-log';
+import {BindingController} from '../../binding/controller/binding';
 import {InputBindingController} from '../../binding/controller/input-binding';
 import {MonitorBindingController} from '../../binding/controller/monitor-binding';
 import {FolderController} from '../../folder/controller/folder';
@@ -65,7 +66,7 @@ function createMonitorBindingController(
 		bufferSize: 1,
 		ticker: new ManualTicker(),
 	});
-	return new LabeledValueController(doc, {
+	return new BindingController(doc, {
 		blade: createBlade(),
 		props: ValueMap.fromObject<LabelPropsObject>({
 			label: '',

--- a/packages/core/src/blade/label/controller/value-label.ts
+++ b/packages/core/src/blade/label/controller/value-label.ts
@@ -16,6 +16,11 @@ interface Config<T, C extends ValueController<T>, Va extends Value<T>> {
 	value: Va;
 	valueController: C;
 }
+export type LabeledValueConfig<
+	T,
+	C extends ValueController<T>,
+	Va extends Value<T>,
+> = Config<T, C, Va>;
 
 export class LabeledValueController<
 	T,

--- a/packages/core/src/blade/plugin.ts
+++ b/packages/core/src/blade/plugin.ts
@@ -1,4 +1,4 @@
-import {MicroParsers} from '../common/micro-parsers';
+import {parseRecord} from '../common/micro-parsers';
 import {ViewProps} from '../common/model/view-props';
 import {BaseBladeParams} from '../common/params';
 import {forceCast} from '../misc/type-util';
@@ -49,20 +49,22 @@ export function createBladeController<P extends BaseBladeParams>(
 		return null;
 	}
 
-	const p = MicroParsers;
-	const disabled = p.optional.boolean(args.params['disabled']).value;
-	const hidden = p.optional.boolean(args.params['hidden']).value;
+	const params = parseRecord(args.params, (p) => ({
+		disabled: p.optional.boolean,
+		hidden: p.optional.boolean,
+	}));
+
 	return plugin.controller({
 		blade: createBlade(),
 		document: args.document,
 		params: forceCast({
 			...ac.params,
-			disabled: disabled,
-			hidden: hidden,
+			disabled: params?.disabled,
+			hidden: params?.hidden,
 		}),
 		viewProps: ViewProps.create({
-			disabled: disabled,
-			hidden: hidden,
+			disabled: params?.disabled,
+			hidden: params?.hidden,
 		}),
 	});
 }

--- a/packages/core/src/common/params.ts
+++ b/packages/core/src/common/params.ts
@@ -18,18 +18,23 @@ export interface PointDimensionParams {
 
 export type PickerLayout = 'inline' | 'popup';
 
-export interface BaseInputParams extends BaseParams, Record<string, unknown> {
+interface BindingParams extends BaseParams {
 	label?: string;
-	readonly?: false;
 	view?: string;
 }
 
-export interface BaseMonitorParams extends BaseParams, Record<string, unknown> {
+export interface BaseInputParams
+	extends BindingParams,
+		Record<string, unknown> {
+	readonly?: false;
+}
+
+export interface BaseMonitorParams
+	extends BindingParams,
+		Record<string, unknown> {
 	bufferSize?: number;
 	interval?: number;
-	label?: string;
 	readonly: true;
-	view?: string;
 }
 
 export interface BaseBladeParams extends BaseParams, Record<string, unknown> {}

--- a/packages/core/src/common/params.ts
+++ b/packages/core/src/common/params.ts
@@ -20,6 +20,7 @@ export type PickerLayout = 'inline' | 'popup';
 
 interface BindingParams extends BaseParams {
 	label?: string;
+	tag?: string | undefined;
 	view?: string;
 }
 

--- a/packages/core/src/input-binding/plugin.ts
+++ b/packages/core/src/input-binding/plugin.ts
@@ -163,6 +163,7 @@ export function createInputBindingController<In, Ex, P extends BaseInputParams>(
 		disabled: p.optional.boolean,
 		hidden: p.optional.boolean,
 		label: p.optional.string,
+		tag: p.optional.string,
 	}));
 
 	// Binding and value
@@ -202,6 +203,7 @@ export function createInputBindingController<In, Ex, P extends BaseInputParams>(
 		props: ValueMap.fromObject<LabelPropsObject>({
 			label: params?.label ?? args.target.key,
 		}),
+		tag: params?.tag,
 		value: value,
 		valueController: controller,
 	});

--- a/packages/core/src/input-binding/plugin.ts
+++ b/packages/core/src/input-binding/plugin.ts
@@ -8,7 +8,7 @@ import {BindingTarget} from '../common/binding/target';
 import {InputBindingValue} from '../common/binding/value/input-binding';
 import {Constraint} from '../common/constraint/constraint';
 import {ValueController} from '../common/controller/value';
-import {MicroParsers} from '../common/micro-parsers';
+import {parseRecord} from '../common/micro-parsers';
 import {Value} from '../common/model/value';
 import {ValueMap} from '../common/model/value-map';
 import {createValue} from '../common/model/values';
@@ -153,13 +153,17 @@ export function createInputBindingController<In, Ex, P extends BaseInputParams>(
 		return null;
 	}
 
-	const p = MicroParsers;
-
 	const valueArgs = {
 		target: args.target,
 		initialValue: result.initialValue,
 		params: result.params,
 	};
+
+	const params = parseRecord(args.params, (p) => ({
+		disabled: p.optional.boolean,
+		hidden: p.optional.boolean,
+		label: p.optional.string,
+	}));
 
 	// Binding and value
 	const reader = plugin.binding.reader(valueArgs);
@@ -180,8 +184,6 @@ export function createInputBindingController<In, Ex, P extends BaseInputParams>(
 	);
 
 	// Value controller
-	const disabled = p.optional.boolean(args.params.disabled).value;
-	const hidden = p.optional.boolean(args.params.hidden).value;
 	const controller = plugin.controller({
 		constraint: constraint,
 		document: args.document,
@@ -189,17 +191,16 @@ export function createInputBindingController<In, Ex, P extends BaseInputParams>(
 		params: result.params,
 		value: value,
 		viewProps: ViewProps.create({
-			disabled: disabled,
-			hidden: hidden,
+			disabled: params?.disabled,
+			hidden: params?.hidden,
 		}),
 	});
 
 	// Input binding controller
-	const label = p.optional.string(args.params.label).value;
 	return new InputBindingController(args.document, {
 		blade: createBlade(),
 		props: ValueMap.fromObject<LabelPropsObject>({
-			label: label ?? args.target.key,
+			label: params?.label ?? args.target.key,
 		}),
 		value: value,
 		valueController: controller,

--- a/packages/core/src/misc/type-util.ts
+++ b/packages/core/src/misc/type-util.ts
@@ -16,6 +16,10 @@ export function isObject(value: unknown): value is object {
 	return value !== null && typeof value === 'object';
 }
 
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object';
+}
+
 export function deepEqualsArray<T>(a1: T[], a2: T[]): boolean {
 	if (a1.length !== a2.length) {
 		return false;

--- a/packages/core/src/monitor-binding/number/api/graph-log-test.ts
+++ b/packages/core/src/monitor-binding/number/api/graph-log-test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
+import {BindingController} from '../../../blade/binding/controller/binding';
 import {createBlade} from '../../../blade/common/model/blade';
-import {LabeledValueController} from '../../../blade/label/controller/value-label';
 import {LabelPropsObject} from '../../../blade/label/view/label';
 import {ReadonlyBinding} from '../../../common/binding/readonly';
 import {BindingTarget} from '../../../common/binding/target';
@@ -32,7 +32,7 @@ function createApi(config: {
 		bufferSize: 10,
 		ticker: new ManualTicker(),
 	});
-	const c = new LabeledValueController<
+	const c = new BindingController<
 		TpBuffer<number>,
 		GraphLogController,
 		MonitorBindingValue<number>

--- a/packages/core/src/monitor-binding/plugin.ts
+++ b/packages/core/src/monitor-binding/plugin.ts
@@ -1,10 +1,10 @@
 import {MonitorBindingApi} from '../blade/binding/api/monitor-binding';
+import {BindingController} from '../blade/binding/controller/binding';
 import {
 	BufferedValueController,
 	MonitorBindingController,
 } from '../blade/binding/controller/monitor-binding';
 import {createBlade} from '../blade/common/model/blade';
-import {LabeledValueController} from '../blade/label/controller/value-label';
 import {LabelPropsObject} from '../blade/label/view/label';
 import {BindingReader} from '../common/binding/binding';
 import {ReadonlyBinding} from '../common/binding/readonly';
@@ -185,7 +185,7 @@ export function createMonitorBindingController<T, P extends BaseMonitorParams>(
 	});
 
 	// Monitor binding controller
-	return new LabeledValueController(args.document, {
+	return new BindingController(args.document, {
 		blade: createBlade(),
 		props: ValueMap.fromObject<LabelPropsObject>({
 			label: params?.label,


### PR DESCRIPTION
Should be useful as an alternative to `presetKey`. #431 