### PR TITLE
patch(ButtonApi): patched ".on()" method with missing key property

### DIFF
--- a/packages/core/src/blade/button/api/button.ts
+++ b/packages/core/src/blade/button/api/button.ts
@@ -35,7 +35,7 @@ export class ButtonApi
 		const emitter = this.controller.buttonController.emitter;
 		emitter.on(eventName, (ev) => {
 			bh(new TpMouseEvent(this, ev.nativeEvent));
-		});
+		}, { key: handler });
 		return this;
 	}
 

--- a/packages/core/src/blade/button/api/button.ts
+++ b/packages/core/src/blade/button/api/button.ts
@@ -33,9 +33,13 @@ export class ButtonApi
 	): this {
 		const bh = handler.bind(this);
 		const emitter = this.controller.buttonController.emitter;
-		emitter.on(eventName, (ev) => {
-			bh(new TpMouseEvent(this, ev.nativeEvent));
-		}, { key: handler });
+		emitter.on(
+			eventName,
+			(ev) => {
+				bh(new TpMouseEvent(this, ev.nativeEvent));
+			},
+			{key: handler},
+		);
 		return this;
 	}
 


### PR DESCRIPTION
### Problem

ButtonApi does not implement correctly Emitter model since it does wrap handler with arrow function without setting handler key ([packages/core/src/blade/api/button.ts](https://github.com/cocopon/tweakpane/blob/main/packages/core/src/blade/button/api/button.ts#L30C1-L40C3)). Therefore, using the same handler within `.off` method to unregister listener basically does not work since reference does not exist - [as presented here](https://codesandbox.io/p/sandbox/blissful-almeida-yzrq9w).
